### PR TITLE
Update HARDWARE-INFO.md

### DIFF
--- a/HARDWARE-INFO.md
+++ b/HARDWARE-INFO.md
@@ -33,6 +33,7 @@ Note: Thank you for testing this out! Are you using an antenna? At the beginning
 | Redgar Nord            | HP ProBook 4340s, Linux               | Sharp radio, whip antenna       | ~1590 kHz, [linux port][12]   | 6-7", very orientation dependent                                |
 | Redgar Nord            | RaspberryPi, Linux                     | Sharp radio, whip antenna       | ~1590 kHz, [linux port][12]   | No signal at all                                               |
 | Erin Pinheiro          | Acer Aspire E1-572-6 BR691  | Generic AM radio, retractable antenna | ~1590 kHz, [linux port][12]   | Slightly noisy result, 10-20cm - `https://dl.dropboxusercontent.com/u/9435923/code/audio_2016-03-02_18-24-30.ogg`
+| Trevor Summerfield | MacBook Pro (Retina, 15-inch, Mid 2015) | Grundig G8 Traveler II Digital, Internal AM Antenna | 1580khz | 50dbu signal, 0db SNR, but audible tones up to several inches above keyboard |
 
 [1]: https://github.com/anfractuosity/system-bus-radio/blob/master/main.c
 [2]: https://github.com/EzoeRyou/system-bus-radio/blob/master/main.cpp


### PR DESCRIPTION
Added test results using MacBook Pro (Retina, 15-inch, Mid 2015) and Grundig G8 Traveler II Digital.