### PR TITLE
performance improvement

### DIFF
--- a/In Javascript/airgap.js
+++ b/In Javascript/airgap.js
@@ -9,8 +9,10 @@ function now() {
 var NSEC_PER_SEC = 1000000000;
 var register = 3.1415
 
+var logs = document.getElementById('logs');
+
 function square_am_signal(time,freq) {
-    document.getElementById('logs').value += "Playing / "+time+" seconds / "+freq+"Hz\n";
+    logs.value += "Playing / "+time+" seconds / "+freq+"Hz\n";
     var period = NSEC_PER_SEC/freq;
     var start = now();
     var end = now()+time*NSEC_PER_SEC;


### PR DESCRIPTION
You don't need to get the element each time square_am_signal is called. DOM access is not that fast, reducing access to it saves a lot of performance.
