### PR TITLE
Updated song parser for JS

### DIFF
--- a/In Javascript/airgap.html
+++ b/In Javascript/airgap.html
@@ -47,7 +47,7 @@
 790 2093</textarea>
 		<div style="font-size:14px">Ported by <a href="https://github.com/quanyang">Yeo Quan Yang</a> & maintained by <a href="https://github.com/rocketinventor">Elliot Gerchak</a>.
 			<br>
-			Original machine code by <a href="https://github.com/fulldecent">William Entriken.</a></div><br/>
+			Original machine code by <a href="https://github.com/fulldecent">William Entriken</a>.</div><br/>
 		<div style="font-size:14px">Project site at <a href="https://github.com/fulldecent/system-bus-radio">https://github.com/fulldecent/system-bus-radio</a></div><br/>
 		<div style="font-size:14px">List of computers that work and what frequency to try at <a href="https://github.com/fulldecent/system-bus-radio/blob/master/TEST-DATA.tsv">https://github.com/fulldecent/system-bus-radio/blob/master/TEST-DATA.tsv</a></div>
 	</div>

--- a/In Javascript/airgap.html
+++ b/In Javascript/airgap.html
@@ -16,8 +16,35 @@
 	<div class="content">
 		</br>
 		<input type="button" value="Play Song" onclick="start()"></br></br>
-		<textarea id="logs" style="width:70%;min-height:300px">Tested with Chrome at 1560Khz
-		</textarea>
+		<textarea id="logs" style="width:70%;min-height:100px">Tested with Chrome at 1560Khz</textarea>
+		<textarea id="tones" style="width:70%;min-height:200px">
+Feel free to edit the code below. Just make sure you keep to the format that it's in and have all of the punctuation.
+:beep frequency=2673 length=400;
+:beep frequency=2349 length=400;
+:beep frequency=2093 length=400;
+:beep frequency=2349 length=400;
+:beep frequency=2673 length=400;
+:beep frequency=2673 length=400;
+:beep frequency=2673 length=790;
+:beep frequency=2349 length=400;
+:beep frequency=2349 length=400;
+:beep frequency=2349 length=790;
+:beep frequency=2673 length=400;
+:beep frequency=3136 length=400;
+:beep frequency=3136 length=790;
+:beep frequency=2673 length=400;
+:beep frequency=2349 length=400;
+:beep frequency=2093 length=400;
+:beep frequency=2349 length=400;
+:beep frequency=2673 length=400;
+:beep frequency=2673 length=400;
+:beep frequency=2673 length=400;
+:beep frequency=2673 length=400;
+:beep frequency=2349 length=400;
+:beep frequency=2349 length=400;
+:beep frequency=2673 length=400;
+:beep frequency=2349 length=400;
+:beep frequency=2093 length=790;</textarea>
 		<div style="font-size:14px">Ported by Yeo Quan Yang. Credits to the original author William Entriken @https://github.com/fulldecent</div><br/>
 		<div style="font-size:14px">Project site at <a href="https://github.com/fulldecent/system-bus-radio">https://github.com/fulldecent/system-bus-radio</a></div><br/>
 		<div style="font-size:14px">List of computers that work and what frequency to try at <a href="https://github.com/fulldecent/system-bus-radio/blob/master/TEST-DATA.tsv">https://github.com/fulldecent/system-bus-radio/blob/master/TEST-DATA.tsv</a></div>

--- a/In Javascript/airgap.html
+++ b/In Javascript/airgap.html
@@ -45,7 +45,9 @@
 400 2673
 400 2349
 790 2093</textarea>
-		<div style="font-size:14px">Ported by Yeo Quan Yang. Credits to the original author William Entriken @https://github.com/fulldecent</div><br/>
+		<div style="font-size:14px">Ported by <a href="https://github.com/quanyang">Yeo Quan Yang</a> & maintained by <a href="https://github.com/rocketinventor">Elliot Gerchak</a>.
+			<br>
+			Original machine code by <a href="https://github.com/fulldecent">William Entriken.</a></div><br/>
 		<div style="font-size:14px">Project site at <a href="https://github.com/fulldecent/system-bus-radio">https://github.com/fulldecent/system-bus-radio</a></div><br/>
 		<div style="font-size:14px">List of computers that work and what frequency to try at <a href="https://github.com/fulldecent/system-bus-radio/blob/master/TEST-DATA.tsv">https://github.com/fulldecent/system-bus-radio/blob/master/TEST-DATA.tsv</a></div>
 	</div>

--- a/In Javascript/airgap.html
+++ b/In Javascript/airgap.html
@@ -17,34 +17,34 @@
 		</br>
 		<input type="button" value="Play Song" onclick="start()"></br></br>
 		<textarea id="logs" style="width:70%;min-height:100px">Tested with Chrome at 1560Khz</textarea>
+		<p style="font-size:14px">Feel free to edit the code below or copy and paste any <em>valid</em> code.<br>Column one is time in <i>milliseconds</i>, and column two is <i>frequency</i>.</p>
 		<textarea id="tones" style="width:70%;min-height:200px">
-Feel free to edit the code below. Just make sure you keep to the format that it's in and have all of the punctuation.
-:beep frequency=2673 length=400;
-:beep frequency=2349 length=400;
-:beep frequency=2093 length=400;
-:beep frequency=2349 length=400;
-:beep frequency=2673 length=400;
-:beep frequency=2673 length=400;
-:beep frequency=2673 length=790;
-:beep frequency=2349 length=400;
-:beep frequency=2349 length=400;
-:beep frequency=2349 length=790;
-:beep frequency=2673 length=400;
-:beep frequency=3136 length=400;
-:beep frequency=3136 length=790;
-:beep frequency=2673 length=400;
-:beep frequency=2349 length=400;
-:beep frequency=2093 length=400;
-:beep frequency=2349 length=400;
-:beep frequency=2673 length=400;
-:beep frequency=2673 length=400;
-:beep frequency=2673 length=400;
-:beep frequency=2673 length=400;
-:beep frequency=2349 length=400;
-:beep frequency=2349 length=400;
-:beep frequency=2673 length=400;
-:beep frequency=2349 length=400;
-:beep frequency=2093 length=790;</textarea>
+400 2673
+400 2349
+400 2093
+400 2349
+400 2673
+400 2673
+790 2673
+400 2349
+400 2349
+790 2349
+400 2673
+400 3136
+790 3136
+400 2673
+400 2349
+400 2093
+400 2349
+400 2673
+400 2673
+400 2673
+400 2673
+400 2349
+400 2349
+400 2673
+400 2349
+790 2093</textarea>
 		<div style="font-size:14px">Ported by Yeo Quan Yang. Credits to the original author William Entriken @https://github.com/fulldecent</div><br/>
 		<div style="font-size:14px">Project site at <a href="https://github.com/fulldecent/system-bus-radio">https://github.com/fulldecent/system-bus-radio</a></div><br/>
 		<div style="font-size:14px">List of computers that work and what frequency to try at <a href="https://github.com/fulldecent/system-bus-radio/blob/master/TEST-DATA.tsv">https://github.com/fulldecent/system-bus-radio/blob/master/TEST-DATA.tsv</a></div>

--- a/In Javascript/airgap.js
+++ b/In Javascript/airgap.js
@@ -3,27 +3,26 @@
 //Tested to be working on Chrome at 1560khz
 
 function now() {
- return performance.now()*1000000;
+	return window.performance.now() * 1000000;
 }
 
 var NSEC_PER_SEC = 1000000000;
 var register = 3.1415;
 
-function square_am_signal(time,freq) {
-	document.getElementById('logs').value += "Playing / "+time+" seconds / "+freq+"Hz\n";
-	var period = NSEC_PER_SEC/freq;
+function square_am_signal(time, freq) {
+	document.getElementById('logs').value += "Playing / " + time + " seconds / " + freq + "Hz\n";
+	var period = NSEC_PER_SEC / freq;
 	var start = now();
-	var end = now()+time*NSEC_PER_SEC;
+	var end = now() + time * NSEC_PER_SEC;
 	while (now() < end) {
-		var mid = start+period/2;
-		var reset = start+period;
-		while (now()<mid) {
+		var mid = start + period / 2;
+		var reset = start + period;
+		while (now() < mid) {
 			for (var i = 0; i < 100; i++) {
 				register = 1 - Math.log(register) / 1.7193;
 			}
 		}
-		while(now() < reset){
-		}
+		while (now() < reset) {}
 		start = reset;
 	}
 }
@@ -31,12 +30,13 @@ function square_am_signal(time,freq) {
 function start() {
 	var song = document.getElementById("tones").value.split(":");
 	var length = song.length;
-	var i = 1, line, time, freq;
+	var i = 1,
+		line, time, freq;
 	while (1 <= length) {
 		line = song[i].split(" ");
 		if (line[0] == "beep") {
 			freq = +line[0].split("=")[1];
-			time = +line[2].split("=")[1].slice(0,-1);
+			time = +line[2].split("=")[1].slice(0, -1);
 			square_am_signal(time, freq);
 		}
 		if (line[0] == "delay") {

--- a/In Javascript/airgap.js
+++ b/In Javascript/airgap.js
@@ -7,25 +7,25 @@ function now() {
 }
 
 var NSEC_PER_SEC = 1000000000;
-var register = 3.1415
+var register = 3.1415;
 
 function square_am_signal(time,freq) {
-    document.getElementById('logs').value += "Playing / "+time+" seconds / "+freq+"Hz\n";
-    var period = NSEC_PER_SEC/freq;
-    var start = now();
-    var end = now()+time*NSEC_PER_SEC;
-    while (now() < end) {
-        var mid = start+period/2;
-        var reset = start+period;
-        while (now()<mid) {
-            for (i = 0; i < 100; i++) {
-                register = 1 - Math.log(register) / 1.7193
-            }
-        }
-        while(now() < reset){
-        }
-        start = reset
-    }
+	document.getElementById('logs').value += "Playing / "+time+" seconds / "+freq+"Hz\n";
+	var period = NSEC_PER_SEC/freq;
+	var start = now();
+	var end = now()+time*NSEC_PER_SEC;
+	while (now() < end) {
+		var mid = start+period/2;
+		var reset = start+period;
+		while (now()<mid) {
+			for (var i = 0; i < 100; i++) {
+				register = 1 - Math.log(register) / 1.7193;
+			}
+		}
+		while(now() < reset){
+		}
+		start = reset;
+	}
 }
 
 function start() {

--- a/In Javascript/airgap.js
+++ b/In Javascript/airgap.js
@@ -29,30 +29,22 @@ function square_am_signal(time,freq) {
 }
 
 function start() {
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.400, 2093);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.790, 2673);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.790, 2349);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 3136);
-    square_am_signal(0.790, 3136);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.400, 2093);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.400, 2673);
-    square_am_signal(0.400, 2349);
-    square_am_signal(0.790, 2093);
+	var song = document.getElementById("tones").value.split(":");
+	var length = song.length;
+	var i = 1, line, time, freq;
+	while (1 <= length) {
+		line = song[i].split(" ");
+		if (line[0] == "beep") {
+			freq = +line[0].split("=")[1];
+			time = +line[2].split("=")[1].slice(0,-1);
+			square_am_signal(time, freq);
+		}
+		if (line[0] == "delay") {
+			// delay
+		}
+		if (song[i] == "end") {
+			i = 1;
+		}
+		i++;
+	}
 }

--- a/In Javascript/airgap.js
+++ b/In Javascript/airgap.js
@@ -28,23 +28,18 @@ function square_am_signal(time, freq) {
 }
 
 function start() {
-	var song = document.getElementById("tones").value.split(":");
+	var song = document.getElementById("tones").value.split("\n");
 	var length = song.length;
-	var i = 1,
-		line, time, freq;
-	while (1 <= length) {
+	var line, time, freq;
+	for (var i = 0; i < length; i++) {
 		line = song[i].split(" ");
-		if (line[0] == "beep") {
-			freq = +line[0].split("=")[1];
-			time = +line[2].split("=")[1].slice(0, -1);
-			square_am_signal(time, freq);
-		}
-		if (line[0] == "delay") {
+		if (line[1] == "0") {
 			// delay
 		}
-		if (song[i] == "end") {
-			i = 1;
+		else {
+			freq = +line[1];
+			time = +line[0];
+			square_am_signal(time, freq);
 		}
-		i++;
 	}
 }

--- a/In Javascript/main.css
+++ b/In Javascript/main.css
@@ -98,3 +98,14 @@ input, textarea, keygen, select, button, isindex {
     outline:none;
     resize: none;
 }
+a
+{
+    color: white;
+    font-weight:bold;
+    background-color: rgba(220, 220, 220, 0.35);
+    text-decoration:none;
+}
+a:hover
+{
+    background-color: rgba(240, 240, 240, 0.52);
+}

--- a/smb.song
+++ b/smb.song
@@ -1,0 +1,352 @@
+:beep frequency=660 length=100ms;
+:delay 150ms;
+:beep frequency=660 length=100ms;
+:delay 300ms;
+:beep frequency=660 length=100ms;
+:delay 300ms;
+:beep frequency=510 length=100ms;
+:delay 100ms;
+:beep frequency=660 length=100ms;
+:delay 300ms;
+:beep frequency=770 length=100ms;
+:delay 550ms;
+:beep frequency=380 length=100ms;
+:delay 575ms;
+
+:beep frequency=510 length=100ms;
+:delay 450ms;
+:beep frequency=380 length=100ms;
+:delay 400ms;
+:beep frequency=320 length=100ms;
+:delay 500ms;
+:beep frequency=440 length=100ms;
+:delay 300ms;
+:beep frequency=480 length=80ms;
+:delay 330ms;
+:beep frequency=450 length=100ms;
+:delay 150ms;
+:beep frequency=430 length=100ms;
+:delay 300ms;
+:beep frequency=380 length=100ms;
+:delay 200ms;
+:beep frequency=660 length=80ms;
+:delay 200ms;
+:beep frequency=760 length=50ms;
+:delay 150ms;
+:beep frequency=860 length=100ms;
+:delay 300ms;
+:beep frequency=700 length=80ms;
+:delay 150ms;
+:beep frequency=760 length=50ms;
+:delay 350ms;
+:beep frequency=660 length=80ms;
+:delay 300ms;
+:beep frequency=520 length=80ms;
+:delay 150ms;
+:beep frequency=580 length=80ms;
+:delay 150ms;
+:beep frequency=480 length=80ms;
+:delay 500ms;
+
+:beep frequency=510 length=100ms;
+:delay 450ms;
+:beep frequency=380 length=100ms;
+:delay 400ms;
+:beep frequency=320 length=100ms;
+:delay 500ms;
+:beep frequency=440 length=100ms;
+:delay 300ms;
+:beep frequency=480 length=80ms;
+:delay 330ms;
+:beep frequency=450 length=100ms;
+:delay 150ms;
+:beep frequency=430 length=100ms;
+:delay 300ms;
+:beep frequency=380 length=100ms;
+:delay 200ms;
+:beep frequency=660 length=80ms;
+:delay 200ms;
+:beep frequency=760 length=50ms;
+:delay 150ms;
+:beep frequency=860 length=100ms;
+:delay 300ms;
+:beep frequency=700 length=80ms;
+:delay 150ms;
+:beep frequency=760 length=50ms;
+:delay 350ms;
+:beep frequency=660 length=80ms;
+:delay 300ms;
+:beep frequency=520 length=80ms;
+:delay 150ms;
+:beep frequency=580 length=80ms;
+:delay 150ms;
+:beep frequency=480 length=80ms;
+:delay 500ms;
+
+:beep frequency=500 length=100ms;
+:delay 300ms;
+
+:beep frequency=760 length=100ms;
+:delay 100ms;
+:beep frequency=720 length=100ms;
+:delay 150ms;
+:beep frequency=680 length=100ms;
+:delay 150ms;
+:beep frequency=620 length=150ms;
+:delay 300ms;
+
+:beep frequency=650 length=150ms;
+:delay 300ms;
+:beep frequency=380 length=100ms;
+:delay 150ms;
+:beep frequency=430 length=100ms;
+:delay 150ms;
+
+:beep frequency=500 length=100ms;
+:delay 300ms;
+:beep frequency=430 length=100ms;
+:delay 150ms;
+:beep frequency=500 length=100ms;
+:delay 100ms;
+:beep frequency=570 length=100ms;
+:delay 220ms;
+
+:beep frequency=500 length=100ms;
+:delay 300ms;
+
+:beep frequency=760 length=100ms;
+:delay 100ms;
+:beep frequency=720 length=100ms;
+:delay 150ms;
+:beep frequency=680 length=100ms;
+:delay 150ms;
+:beep frequency=620 length=150ms;
+:delay 300ms;
+
+:beep frequency=650 length=200ms;
+:delay 300ms;
+
+:beep frequency=1020 length=80ms;
+:delay 300ms;
+:beep frequency=1020 length=80ms;
+:delay 150ms;
+:beep frequency=1020 length=80ms;
+:delay 300ms;
+
+:beep frequency=380 length=100ms;
+:delay 300ms;
+:beep frequency=500 length=100ms;
+:delay 300ms;
+
+:beep frequency=760 length=100ms;
+:delay 100ms;
+:beep frequency=720 length=100ms;
+:delay 150ms;
+:beep frequency=680 length=100ms;
+:delay 150ms;
+:beep frequency=620 length=150ms;
+:delay 300ms;
+
+:beep frequency=650 length=150ms;
+:delay 300ms;
+:beep frequency=380 length=100ms;
+:delay 150ms;
+:beep frequency=430 length=100ms;
+:delay 150ms;
+
+:beep frequency=500 length=100ms;
+:delay 300ms;
+:beep frequency=430 length=100ms;
+:delay 150ms;
+:beep frequency=500 length=100ms;
+:delay 100ms;
+:beep frequency=570 length=100ms;
+:delay 420ms;
+
+:beep frequency=585 length=100ms;
+:delay 450ms;
+
+:beep frequency=550 length=100ms;
+:delay 420ms;
+
+:beep frequency=500 length=100ms;
+:delay 360ms;
+
+:beep frequency=380 length=100ms;
+:delay 300ms;
+:beep frequency=500 length=100ms;
+:delay 300ms;
+:beep frequency=500 length=100ms;
+:delay 150ms;
+:beep frequency=500 length=100ms;
+:delay 300ms;
+
+:beep frequency=500 length=100ms;
+:delay 300ms;
+
+:beep frequency=760 length=100ms;
+:delay 100ms;
+:beep frequency=720 length=100ms;
+:delay 150ms;
+:beep frequency=680 length=100ms;
+:delay 150ms;
+:beep frequency=620 length=150ms;
+:delay 300ms;
+
+:beep frequency=650 length=150ms;
+:delay 300ms;
+:beep frequency=380 length=100ms;
+:delay 150ms;
+:beep frequency=430 length=100ms;
+:delay 150ms;
+
+:beep frequency=500 length=100ms;
+:delay 300ms;
+:beep frequency=430 length=100ms;
+:delay 150ms;
+:beep frequency=500 length=100ms;
+:delay 100ms;
+:beep frequency=570 length=100ms;
+:delay 220ms;
+
+:beep frequency=500 length=100ms;
+:delay 300ms;
+
+:beep frequency=760 length=100ms;
+:delay 100ms;
+:beep frequency=720 length=100ms;
+:delay 150ms;
+:beep frequency=680 length=100ms;
+:delay 150ms;
+:beep frequency=620 length=150ms;
+:delay 300ms;
+
+:beep frequency=650 length=200ms;
+:delay 300ms;
+
+:beep frequency=1020 length=80ms;
+:delay 300ms;
+:beep frequency=1020 length=80ms;
+:delay 150ms;
+:beep frequency=1020 length=80ms;
+:delay 300ms;
+
+:beep frequency=380 length=100ms;
+:delay 300ms;
+:beep frequency=500 length=100ms;
+:delay 300ms;
+
+:beep frequency=760 length=100ms;
+:delay 100ms;
+:beep frequency=720 length=100ms;
+:delay 150ms;
+:beep frequency=680 length=100ms;
+:delay 150ms;
+:beep frequency=620 length=150ms;
+:delay 300ms;
+
+:beep frequency=650 length=150ms;
+:delay 300ms;
+:beep frequency=380 length=100ms;
+:delay 150ms;
+:beep frequency=430 length=100ms;
+:delay 150ms;
+
+:beep frequency=500 length=100ms;
+:delay 300ms;
+:beep frequency=430 length=100ms;
+:delay 150ms;
+:beep frequency=500 length=100ms;
+:delay 100ms;
+:beep frequency=570 length=100ms;
+:delay 420ms;
+
+:beep frequency=585 length=100ms;
+:delay 450ms;
+
+:beep frequency=550 length=100ms;
+:delay 420ms;
+
+:beep frequency=500 length=100ms;
+:delay 360ms;
+
+:beep frequency=380 length=100ms;
+:delay 300ms;
+:beep frequency=500 length=100ms;
+:delay 300ms;
+:beep frequency=500 length=100ms;
+:delay 150ms;
+:beep frequency=500 length=100ms;
+:delay 300ms;
+
+:beep frequency=500 length=60ms;
+:delay 150ms;
+:beep frequency=500 length=80ms;
+:delay 300ms;
+:beep frequency=500 length=60ms;
+:delay 350ms;
+:beep frequency=500 length=80ms;
+:delay 150ms;
+:beep frequency=580 length=80ms;
+:delay 350ms;
+:beep frequency=660 length=80ms;
+:delay 150ms;
+:beep frequency=500 length=80ms;
+:delay 300ms;
+:beep frequency=430 length=80ms;
+:delay 150ms;
+:beep frequency=380 length=80ms;
+:delay 600ms;
+
+:beep frequency=500 length=60ms;
+:delay 150ms;
+:beep frequency=500 length=80ms;
+:delay 300ms;
+:beep frequency=500 length=60ms;
+:delay 350ms;
+:beep frequency=500 length=80ms;
+:delay 150ms;
+:beep frequency=580 length=80ms;
+:delay 150ms;
+:beep frequency=660 length=80ms;
+:delay 550ms;
+
+:beep frequency=870 length=80ms;
+:delay 325ms;
+:beep frequency=760 length=80ms;
+:delay 600ms;
+
+:beep frequency=500 length=60ms;
+:delay 150ms;
+:beep frequency=500 length=80ms;
+:delay 300ms;
+:beep frequency=500 length=60ms;
+:delay 350ms;
+:beep frequency=500 length=80ms;
+:delay 150ms;
+:beep frequency=580 length=80ms;
+:delay 350ms;
+:beep frequency=660 length=80ms;
+:delay 150ms;
+:beep frequency=500 length=80ms;
+:delay 300ms;
+:beep frequency=430 length=80ms;
+:delay 150ms;
+:beep frequency=380 length=80ms;
+:delay 600ms;
+
+:beep frequency=660 length=100ms;
+:delay 150ms;
+:beep frequency=660 length=100ms;
+:delay 300ms;
+:beep frequency=660 length=100ms;
+:delay 300ms;
+:beep frequency=510 length=100ms;
+:delay 100ms;
+:beep frequency=660 length=100ms;
+:delay 300ms;
+:beep frequency=770 length=100ms;
+:delay 550ms;
+:beep frequency=380 length=100ms;
+:delay 575ms;
+:end


### PR DESCRIPTION
Based on the work of pull request #1 _("Quick and dirty song parser...")_ by @lberezy...

A textbox has been added to the HTML to allow for the editing of what gets played back. The smb.song file has also been included and can be played back by copying and pasting it into the textbox. Everything from #1 except for the "delay" command has been implemented. (JS doesn't really have a good way to do that.)

This pull request also makes **various fixes to the code of the Vanilla JS** port including undefined vars, code spacing, etc.