### PR TITLE
Fixed bug in docs/airgap.js that prevented it from reading changes to the tune input

### DIFF
--- a/docs/airgap.js
+++ b/docs/airgap.js
@@ -16,7 +16,7 @@ function start() { // Start Web Worker & send song data to player
 		};
 
 		// Send song data to player
-		var song = document.getElementById("tune").innerHTML;
+		var song = document.getElementById("tune").value;
 		player.postMessage(song);
 	}
 }


### PR DESCRIPTION
A textarea's `value` attribute gives its current, user-provided contents, while `innerHTML` sometimes gives its default contents. `value` should always be used to get the latest contents. See the specs: https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-value